### PR TITLE
Sanitizes generated branch names

### DIFF
--- a/branch.ts
+++ b/branch.ts
@@ -103,6 +103,22 @@ export class BranchNameGenerator {
     const maxGenerativeLength = this.MAX_BRANCH_LENGTH - prefix.length - ticketId.length - 1;
     const truncatedGenerative = generativePart.substring(0, maxGenerativeLength);
 
-    return `${prefix}${ticketId}-${truncatedGenerative}`;
+    return `${prefix}${ticketId}-${this.sanitizeBranchName(truncatedGenerative)}`;
+  }
+
+  private static sanitizeBranchName(branchName: string): string {
+    return branchName
+      // Replace invalid characters with hyphens
+      .replace(/[^a-zA-Z0-9\-_\/]/g, '-')
+      // Replace multiple consecutive hyphens with single hyphen
+      .replace(/-+/g, '-')
+      // Remove leading/trailing hyphens and slashes
+      .replace(/^[-\/]+|[-\/]+$/g, '')
+      // Ensure it doesn't start with a dot (hidden files)
+      .replace(/^\./, '')
+      // Ensure it doesn't end with .lock
+      .replace(/\.lock$/, '')
+      // Remove backticks (like `id` or `id`)
+      .replace(/`/g, '');
   }
 }


### PR DESCRIPTION
This pull request introduces a change to the `BranchNameGenerator` class in `branch.ts` to improve the handling of branch names by sanitizing them to meet naming conventions and avoid potential issues.

### Improvements to branch name generation:

* [`branch.ts`](diffhunk://#diff-7a3c84030b117dff74d14ba7d8d455b4f0d154b8e58c04e29e28f712ca5b886eL106-R122): Added a new private static method `sanitizeBranchName` to clean up branch names by replacing invalid characters, removing leading/trailing hyphens or slashes, and ensuring names do not start with a dot, end with `.lock`, or contain backticks. The `generateBranchName` method now uses this sanitization step before returning the branch name.