### PR TITLE
Updates max_tokens parameter name

### DIFF
--- a/ai-service.ts
+++ b/ai-service.ts
@@ -119,7 +119,7 @@ export class AIService {
           }
         ],
         temperature: this.aiConfig.temperature,
-        max_tokens: this.aiConfig.maxTokens,
+        max_completion_tokens: this.aiConfig.maxTokens,
       });
 
       const content = response.choices[0]?.message?.content;
@@ -211,7 +211,7 @@ Return only the branch suffix (no ticket ID):
           }
         ],
         temperature: this.aiConfig.summaryTemperature,
-        max_tokens: this.aiConfig.summaryMaxTokens,
+        max_completion_tokens: this.aiConfig.summaryMaxTokens,
       });
 
       const content = response.choices[0]?.message?.content?.trim();
@@ -235,7 +235,7 @@ Return only the branch suffix (no ticket ID):
       await this.openai.chat.completions.create({
         model: this.aiConfig.model,
         messages: [{ role: "user", content: "Hello" }],
-        max_tokens: 5,
+        max_completion_tokens: 5,
       });
       return true;
     } catch {


### PR DESCRIPTION
This pull request updates the parameter name for specifying the maximum number of tokens in API requests to align with the latest OpenAI API changes. The changes ensure consistency and compatibility across the `ai-service.ts` file.

Parameter renaming for OpenAI API compatibility:

* Updated `max_tokens` to `max_completion_tokens` in three locations within `ai-service.ts` to reflect the updated OpenAI API parameter naming convention. [[1]](diffhunk://#diff-938b3d5829ead54bee3e811d2a61fb6fa50d218ac3705f4810f519a6bb0d5446L122-R122) [[2]](diffhunk://#diff-938b3d5829ead54bee3e811d2a61fb6fa50d218ac3705f4810f519a6bb0d5446L214-R214) [[3]](diffhunk://#diff-938b3d5829ead54bee3e811d2a61fb6fa50d218ac3705f4810f519a6bb0d5446L238-R238)